### PR TITLE
02번 문제 제출

### DIFF
--- a/Q_02/.vsconfig
+++ b/Q_02/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Q_02/Assets/Scripts/PlayerMovement.cs
+++ b/Q_02/Assets/Scripts/PlayerMovement.cs
@@ -22,13 +22,16 @@ public class PlayerMovement : MonoBehaviour
     }
 
     private void MovePosition()
-    {
+    {  // 1.4 배는 nomalized 안해서 생김
+       // 해당 코드는 좌표를 일정 시간에 따라 이동해야 하는데 대각선이 1.4 배 길어서 동일 시간내에 목표지점에 도달하려면
+       // 대각선으로 이동시에 더 빨리 이동하게 됨
+
         Vector3 direction = Vector3.zero;
         direction.x = Input.GetAxisRaw("Horizontal");
         direction.z = Input.GetAxisRaw("Vertical");
-
+        
         if (direction == Vector3.zero) return;
         
-        transform.Translate(_status.MoveSpeed * Time.deltaTime * direction);
+        transform.Translate(_status.MoveSpeed * Time.deltaTime * direction.normalized); // normalized 추가
     }
 }

--- a/Q_02/Assets/Scripts/PlayerStatus.cs
+++ b/Q_02/Assets/Scripts/PlayerStatus.cs
@@ -4,15 +4,17 @@ using UnityEngine;
 
 public class PlayerStatus : MonoBehaviour
 {
-    public float MoveSpeed
+    private float speed;
+    public float MoveSpeed  // 해당 부분에서 자신을 계속 참조해서 무한 루프가 생겨서 터짐 , 실제로 값을 저장할 필드 speed 생성 
     {
-        get => MoveSpeed;
-        private set => MoveSpeed = value;
+        get => speed;
+        private set => speed = value;
     }
 
     private void Awake()
     {
         Init();
+        Debug.Log(speed);
     }
 
     private void Init()


### PR DESCRIPTION
플레이어의 능력치(movespeed) 부분에서 자신을 계속 참조해서 무한 루프가 생겨서 터짐 , 실제로 값을 저장할 필드 speed 생성 

1.4 배는 nomalized 안해서 생김
플레이어 이동 코드는 좌표를 일정 시간에 따라 이동하는데 대각선이 1.4 배 길어서 동일 시간내에 목표지점에 도달하려면
대각선으로 이동시에 더 빨리 이동하게 됨