### PR TITLE
04번  문제 제출

### DIFF
--- a/Q_04/.vsconfig
+++ b/Q_04/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Q_04/Assets/Scripts/StateAttack.cs
+++ b/Q_04/Assets/Scripts/StateAttack.cs
@@ -43,10 +43,21 @@ public class StateAttack : PlayerState
             );
 
         IDamagable damagable;
-        foreach (Collider col in cols)
+        foreach (Collider col in cols)   // 데미지를 입힌 후 idle로 안돌아옴 
         {
+
             damagable = col.GetComponent<IDamagable>();
-            damagable.TakeHit(Controller.AttackValue);
+
+            if (damagable != null)  // null 체크 추가
+            {
+                damagable.TakeHit(Controller.AttackValue);
+            }
+            else 
+            {
+                
+            }
+            
+
         }
     }
 

--- a/Q_04/Assets/Scripts/StateMachine.cs
+++ b/Q_04/Assets/Scripts/StateMachine.cs
@@ -37,7 +37,7 @@ public class StateMachine
 
     public void ChangeState(StateType state)
     {
-        CurrentState.Exit();
+       // CurrentState.Exit();  exit 중복 호출로 스택오버플로우 
         CurrentType = state;
         CurrentState.Enter();
     }


### PR DESCRIPTION
1. 공격 이후에 idle 에 진입하지 못하는 문제 
 - 공격 대상을 찾는 과정중에 IDamagable 인터페이스가 없으면 다음 상태로 진입하지 못함 
    null 을 체크해서 해결 
2. 공격이 끝나고 exit 를 호출하면 스택오버플로우가 생기는 문제 
 - ChangeState에서 exit 를 재호출해서 무한호출하는 문제가 생김 
   해당코드 주석처리로 해결 